### PR TITLE
Use ARGF instead of cheking ARGV and STDIN

### DIFF
--- a/bin/nora2html
+++ b/bin/nora2html
@@ -9,7 +9,7 @@ opt.on('--kconv') {
 }
 
 args = opt.parse(ARGV)
-input = args.length > 0 ? File.open(args[0]).read : STDIN.read
+input = ARGF.read
 input = Kconv.toutf8(input) if auto_convert_encode
 
 puts NoraMark::Document::parse(input).render_parameter(nonpaged: true).html[0]


### PR DESCRIPTION
Do you know [`ARGF`](http://docs.ruby-lang.org/ja/2.1.0/class/ARGF.html) of Ruby? How  about to use it instead of checking `ARGV` and `STDIN` by yourself for readability?

But this patch introduces backward incompatibility:

```
$ git checkout master
$ bundle exec nora2html example/*.nora | wc -l
17
$ git checkout argf
$ bundle exec nora2html example/*.nora | wc -l
628
```

because `ARGF.read` returns text concatenated from multiple files.

If it is okay, could you consider merge this patch?
