### PR TITLE
Add Tilt adapter

### DIFF
--- a/lib/tilt/nora_mark.rb
+++ b/lib/tilt/nora_mark.rb
@@ -1,0 +1,18 @@
+require 'tilt'
+require 'nora_mark'
+
+module Tilt
+  class NoraMarkTemplate < Template
+    protected
+
+    def prepare
+      @document = NoraMark::Document.parse(data).render_parameter(nonpaged: true)
+    end
+
+    def evaluate(scope, locals, &block)
+      @html ||= @document.html[0]
+    end
+  end
+
+  register NoraMarkTemplate, 'nora'
+end

--- a/nora_mark.gemspec
+++ b/nora_mark.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
   gem.add_dependency "kpeg"
+  gem.add_dependency "tilt"
   gem.add_development_dependency "rspec", "~> 2.14"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "byebug"

--- a/spec/fixtures/tilt/html/sample.html
+++ b/spec/fixtures/tilt/html/sample.html
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" xml:lang="ja">
+<head>
+<title>test title</title>
+<link rel="stylesheet" type="text/css" href="css/normalize.css" />
+<link rel="stylesheet" type="text/css" href="css/main.css" />
+</head>
+<body><article><h1 id='heading_index_1'>header 1</h1>
+<div class='pgroup'><p>article comes here.</p>
+<p>linebreak will produce paragraph.</p>
+</div>
+<div class='pgroup'><p>blank line will procude div.pgroup.</p>
+</div>
+<div class='column'><div class='pgroup'><p>This block will produce div.column.</p>
+<p>Inline commands like <a href='http://github.com/skoji/nora_mark/'>this</a> and <span class='strong'>this</span> is available.</p>
+</div>
+</div>
+</article>
+</body>
+</html>

--- a/spec/fixtures/tilt/nora/sample.nora
+++ b/spec/fixtures/tilt/nora/sample.nora
@@ -1,0 +1,18 @@
+---
+lang: ja
+title: test title
+stylesheets: [css/normalize.css, css/main.css]
+---
+
+art {
+    h1: header 1
+    article comes here.
+    linebreak will produce paragraph.
+
+    blank line will procude div.pgroup.
+
+    d.column {
+        This block will produce div.column.
+        Inline commands like [link(http://github.com/skoji/nora_mark/){this}] and [sp.strong{this}] is available.
+    }
+}

--- a/spec/tilt_spec.rb
+++ b/spec/tilt_spec.rb
@@ -1,0 +1,16 @@
+require_relative 'spec_helper'
+require 'pathname'
+require 'tilt/nora_mark'
+
+describe Tilt::NoraMarkTemplate do
+  let(:fixtures_dir) { Pathname.new(__dir__) + 'fixtures/tilt' }
+  subject { Tilt.new(fixtures_dir + 'nora/sample.nora') }
+
+  it "should be registered for '.nora' files" do
+    expect(subject).to be_an_instance_of(Tilt::NoraMarkTemplate)
+  end
+
+  it "should convert '.nora' files to HTML" do
+    expect(subject.render).to eq (fixtures_dir + 'html/sample.html').read
+  end
+end


### PR DESCRIPTION
Hello,

I added Tilt adapter for NoraMark.
Now we can use NoraMark in [Middleman](http://middlemanapp.com/), a static site generator.
Also we can interpolate Ruby code using eRuby mechanism just by adding extension ".erb"(sample.nora.erb).

Could you merge this patch?
